### PR TITLE
replaced current binder badge with newest version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Join the chat at https://gitter.im/WhitakerLab/scona](https://badges.gitter.im/WhitakerLab/scona.svg)](https://gitter.im/WhitakerLab/scona?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/WhitakerLab/scona.svg?branch=master)](https://travis-ci.org/WhitakerLab/scona)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/WhitakerLab/scona/blob/master/LICENSE)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/WhitakerLab/scona/master)
+[![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/WhitakerLab/scona/master)
 
 Welcome to the `scona` GitHub repository! :sparkles:
 


### PR DESCRIPTION


<!---
This is a suggested pull request template for the scona. 
We don't mind whether or not you use it. It's just a list of useful 
questions to answer. :)
-->
- [x] I'm ready to merge

* **What's the context for this pull request?** 
fixes https://github.com/WhitakerLab/scona/issues/89

* **What's new?**
      * followed the link in the "launch binder" badge at the top of the readme.Build failed screenshot 
   
    ![screenshot_2019-02-20 binder beta](https://user-images.githubusercontent.com/12859893/53084920-cf559580-3527-11e9-9ca9-2f457b43edcd.png)
        * replaced the current badge (![](https://camo.githubusercontent.com/24c94be25a8a8b5703a34466825bbfdd6147d9d0/68747470733a2f2f6d7962696e6465722e6f72672f62616467652e737667)) in the readme with the newest version of the badge (![](https://camo.githubusercontent.com/483bae47a175c24dfbfc57390edd8b6982ac5fb3/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)).

![screenshot_2019-02-20 lokesh541 scona](https://user-images.githubusercontent.com/12859893/53085117-32dfc300-3528-11e9-9bdf-f577c931ad45.png)

* **What should a reviewer feedback on?**

* **Does anything need to be updated after merge?** 
_(e.g the wiki or the WhitakerLab website)_
