### PR TITLE
Split brain networks

### DIFF
--- a/scona/graph_measures.py
+++ b/scona/graph_measures.py
@@ -316,7 +316,7 @@ def calculate_nodal_measures(
 
     See Also
     --------
-    :func:`BrainNetwork.calculate_nodal_measures`
+    :func:`BinaryBrainNetwork.calculate_nodal_measures`
     :func:`calc_nodal_partition`
 
     Example
@@ -396,7 +396,7 @@ def rich_club(G):
 
     See Also
     --------
-    :func:`BrainNetwork.rich_club`
+    :func:`BinaryBrainNetwork.rich_club`
     '''
     return nx.rich_club_coefficient(G, normalized=False)
 
@@ -471,7 +471,7 @@ def calculate_global_measures(G,
 
     See Also
     --------
-    :func:`scona.BrainNetwork.calculate_global_measures`
+    :func:`BinaryBrainNetwork.calculate_global_measures`
     '''
     # ==== MEASURES ====================
     if existing_global_measures is not None:

--- a/scona/make_corr_matrices.py
+++ b/scona/make_corr_matrices.py
@@ -60,7 +60,7 @@ def create_residuals_df(df, names, covars=[]):
     '''
     # Raise TypeError if any of the relevant columns are nonnumeric
     non_numeric_cols = get_non_numeric_cols(df[names+covars])
-    if non_numeric_cols:
+    if non_numeric_cols.size > 0:
         raise TypeError('DataFrame columns {} are non numeric'
                         .format(', '.join(non_numeric_cols)))
 
@@ -118,7 +118,7 @@ def create_corrmat(df_res, names=None, method='pearson'):
 
     # Raise TypeError if any of the relevant columns are nonnumeric
     non_numeric_cols = get_non_numeric_cols(df_res)
-    if non_numeric_cols:
+    if non_numeric_cols.size > 0:
         raise TypeError('DataFrame columns {} are non numeric'
                         .format(', '.join(non_numeric_cols)))
 

--- a/scona/make_graphs.py
+++ b/scona/make_graphs.py
@@ -357,7 +357,7 @@ def threshold_graph(G, cost, mst=True):
 
     See Also
     --------
-    :func:`scona.BrainNetwork.threshold`
+    :func:`scona.WeightedBrainNetwork.threshold`
     '''
     # Weights scaled by -1 as minimum_spanning_tree minimises weight
     H = scale_weights(anatomical_copy(G))
@@ -400,6 +400,10 @@ def threshold_graph(G, cost, mst=True):
         germ.add_edges_from(H_edges_sorted_not_germ[:n_edges])
     # binarise edge weights
     nx.set_edge_attributes(germ, name='weight', values=1)
+    # preserve edge weights under the attribute "correlation weighting"
+    nx.set_edge_attributes(germ,
+                           name="correlation weighting",
+                           values=nx.get_edge_attributes(G, name="weight"))
     # And return the updated germ as your graph
     return germ
 

--- a/tests/make_corr_matrices_test.py
+++ b/tests/make_corr_matrices_test.py
@@ -12,9 +12,9 @@ def subject_array():
 
 
 @pytest.fixture
-def subject_data():
+def subject_data(subject_array):
     columns = ['noggin_left', 'noggin_right', 'day of week', 'haircut']
-    data = subject_array()
+    data = subject_array
     return pd.DataFrame(data, columns=columns)
 
 
@@ -25,50 +25,50 @@ def subject_residuals():
     return pd.DataFrame(data, columns=columns)
 
 
-def test_non_numeric_cols():
-    df = subject_residuals()
+def test_non_numeric_cols(subject_residuals):
+    df = subject_residuals
     assert get_non_numeric_cols(df).size == 0
     df['hats'] = 'stetson'
     assert get_non_numeric_cols(df) == np.array(['hats'])
 
 
-def test_create_residuals_df_covars_plural():
+def test_create_residuals_df_covars_plural(subject_array, subject_data):
     names, covars = ['noggin_left', 'noggin_right'], ['day of week', 'haircut']
-    array_resids = [residuals(subject_array()[:, 2:].T,
-                    subject_array()[:, i]) for i in [0, 1]]
+    array_resids = [residuals(subject_array[:, 2:].T,
+                    subject_array[:, i]) for i in [0, 1]]
     np.testing.assert_almost_equal(
-        np.array(create_residuals_df(subject_data(), names, covars)[names]),
+        np.array(create_residuals_df(subject_data, names, covars)[names]),
         np.array(array_resids).T)
 
 
-def test_create_residuals_df_covars_singular():
+def test_create_residuals_df_covars_singular(subject_array, subject_data):
     names, covars = ['noggin_left', 'noggin_right'], ['day of week']
-    array_resids = [residuals(subject_array()[:, 2:3].T,
-                    subject_array()[:, i]) for i in [0, 1]]
+    array_resids = [residuals(subject_array[:, 2:3].T,
+                    subject_array[:, i]) for i in [0, 1]]
     np.testing.assert_almost_equal(
-        np.array(create_residuals_df(subject_data(), names, covars)[names]),
+        np.array(create_residuals_df(subject_data, names, covars)[names]),
         np.array(array_resids).T)
 
 
-def test_create_residuals_df_covars_none():
+def test_create_residuals_df_covars_none(subject_array, subject_data):
     names, covars = ['noggin_left', 'noggin_right'], []
-    array_resids = [residuals(subject_array()[:, 2:2].T, subject_array()[:, i])
+    array_resids = [residuals(subject_array[:, 2:2].T, subject_array[:, i])
                     for i in [0, 1]]
     np.testing.assert_almost_equal(
-        np.array(create_residuals_df(subject_data(), names, covars)[names]),
+        np.array(create_residuals_df(subject_data, names, covars)[names]),
         np.array(array_resids).T)
 
 
-def test_create_corrmat_pearson():
-    df_res = subject_residuals()
+def test_create_corrmat_pearson(subject_residuals):
+    df_res = subject_residuals
     names = ['noggin_left', 'noggin_right']
     np.testing.assert_almost_equal(
         np.array(create_corrmat(df_res, names)),
         np.array([[1, -0.5], [-0.5, 1]]))
 
 
-def test_create_corrmat_spearman():
-    df_res = subject_residuals()
+def test_create_corrmat_spearman(subject_residuals):
+    df_res = subject_residuals
     names = ['noggin_left', 'noggin_right']
     np.testing.assert_almost_equal(
         np.array(create_corrmat(df_res, names, method='spearman')),

--- a/tests/make_graphs_test.py
+++ b/tests/make_graphs_test.py
@@ -16,9 +16,9 @@ def symmetric_df_1():
 
 def simple_weighted_graph():
     G = nx.Graph()
-    G.add_path([1, 2], weight=2)
-    G.add_path([1, 0], weight=3)
-    G.add_path([2, 0], weight=5)
+    nx.add_path(G, [1, 2], weight=2)
+    nx.add_path(G, [1, 0], weight=3)
+    nx.add_path(G, [2, 0], weight=5)
     return G
 
 
@@ -272,7 +272,7 @@ class RandomGraphs(unittest.TestCase):
         cls.lattice_rand = mkg.random_graph(cls.lattice)
         cls.lattice_list = mkg.get_random_graphs(cls.lattice, n=5)
         G = nx.Graph()
-        G.add_path([0, 1, 2])
+        nx.add_path(G, [0, 1, 2])
         cls.short_path = G
 
     def test_random_graph_type(self):


### PR DESCRIPTION
<!---
This is a suggested pull request template for the scona. 
We don't mind whether or not you use it. It's just a list of useful 
questions to answer. :)
-->
- [ ] I'm ready to merge
Not at all. This is just a preview of my proposed changes to seperate the `BrainNetwork` class into two distinct subclasses: `BinaryBrainNetwork` and `WeightedBrainNetwork`.

* **What's the context for this pull request?** 
_(this is a good place to reference any issues that this PR addresses)_
Ruslan discovered that when you run the `threshold` method on an already binarised graph it returns garbage. 
This made me think that there are potentially a lot of situations where treated a weighted network like a binary network or vice versa could be disastrous.

* **What's new?**
My thinking is that the difference between a weighted and a binarised brain network should be very explicit since it's going to determine what sort of analyses we can do on it. 

It should be possible to threshold a `WeightedBrainNetwork` into a `BinaryBrainNetwork` and it should be possible to initialise a `WeightedBrainNetwork` from a correlation matrix.

A `BinaryBrainNetwork` should support all of the network analysis methods. We could run these on a weighted graph no problem, but they would tell us nothing about our data. We will record the original weightings on existent `BinaryBrainNetwork`s in case we want to restrict our focus to fewer edges later (the specific use case being plotting).

* **What should a reviewer feedback on?**
Is this the right direction to go in to solve this problem.

* **Does anything need to be updated after merge?** 
_(e.g the wiki or the WhitakerLab website)_

docs and tutorials would certainly need to be updated, but it's a little early for that.
